### PR TITLE
Use orquestra-python dev as only dev requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,12 +38,7 @@ where = src
 
 [options.extras_require]
 dev =
-    black~=22.3
-    flake8~=3.9.0
-    isort~=5.9.0
-    mypy~=0.910
-    pytest~=6.2
-    pytest-cov>=2.12
+    orquestra-python-dev
 
 [flake8]
 ignore = E203,E266,F401,W605


### PR DESCRIPTION
## Description

Currently, we use dev requirements (e.g. black, mypy, flake8) specified separately in each project. This PR replaces those separate package dependencies into a centralized one managed by us: `orquestra-python-dev`. 

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
