### PR TITLE
Replace SymbolicOperator with PauliRepresentation

### DIFF
--- a/src/orquestra/integrations/qulacs/conversions.py
+++ b/src/orquestra/integrations/qulacs/conversions.py
@@ -1,8 +1,6 @@
 ################################################################################
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
-from numbers import Real
-
 import numpy as np
 import qulacs
 from orquestra.quantum.circuits import Circuit, GateOperation
@@ -95,7 +93,7 @@ def _custom_qulacs_gate(operation: GateOperation):
     return qulacs.gate.DenseMatrix(list(operation.qubit_indices), dense_matrix)
 
 
-def convert_to_qulacs(circuit: Circuit):
+def convert_to_qulacs(circuit: Circuit) -> qulacs.QuantumCircuit:
     qulacs_circuit = qulacs.QuantumCircuit(circuit.n_qubits)
     for operation in circuit.operations:
         qulacs_circuit.add_gate(_qulacs_gate(operation))

--- a/src/orquestra/integrations/qulacs/simulator.py
+++ b/src/orquestra/integrations/qulacs/simulator.py
@@ -8,8 +8,8 @@ import qulacs
 from orquestra.quantum.api.backend import QuantumSimulator, StateVector
 from orquestra.quantum.circuits import Circuit, GateOperation
 from orquestra.quantum.measurements import ExpectationValues, Measurements
-from orquestra.quantum.wip.operators import PauliRepresentation
 from orquestra.quantum.wavefunction import flip_amplitudes, sample_from_wavefunction
+from orquestra.quantum.wip.operators import PauliRepresentation
 from qulacs.observable import create_observable_from_openfermion_text
 
 from .conversions import convert_to_qulacs

--- a/src/orquestra/integrations/qulacs/simulator.py
+++ b/src/orquestra/integrations/qulacs/simulator.py
@@ -43,19 +43,19 @@ class QulacsSimulator(QuantumSimulator):
         expectation_values = []
         qulacs_state = self._get_qulacs_state(circuit)
 
-        for op in qubit_operator.terms:
+        for term in qubit_operator.terms:
             # openfermion text is in the style of '2.0 [Z0 Z1]' if the operator is
             # QubitOperator("Z0 Z1", 2) aka PauliTerm("2*Z0*Z1")
             openfermion_terms_str = " ".join(
-                [f"{pauli_str}{qubit_idx}" for qubit_idx, pauli_str in op._ops.items()]
+                [f"{pauli_str}{qubit_idx}" for qubit_idx, pauli_str in term.operations]
             )
-            openfermion_str = f"{op.coefficient} [{openfermion_terms_str}]"
+            openfermion_str = f"{term.coefficient} [{openfermion_terms_str}]"
             qulacs_observable = create_observable_from_openfermion_text(openfermion_str)
 
             for term_id in range(qulacs_observable.get_term_count()):
-                term = qulacs_observable.get_term(term_id)
+                qulacs_term = qulacs_observable.get_term(term_id)
                 expectation_values.append(
-                    np.real(term.get_expectation_value(qulacs_state))
+                    np.real(qulacs_term.get_expectation_value(qulacs_state))
                 )
         return ExpectationValues(np.array(expectation_values))
 


### PR DESCRIPTION
## Description

Use the new pauli operator data structures instead of openfermion. 

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
