### PR TITLE
Relaxing qulacs version to install in m1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     scipy>=1.4.1
     sympy>=1.5,<=1.9
     cmake>=3.18
-    qulacs==0.5.0
+    qulacs~=0.5.0
     orquestra-quantum
 
 


### PR DESCRIPTION
## Description

The qulacs team has released a wheel for M1/M2 Macs. Qulacs is now installed in M1/M2 but doesn't work. It looks like they now have a working wheel—see [here](https://github.com/qulacs/qulacs/issues/431). Probably they will release a patch version with the new arm64 wheels, so I am relaxing the qulacs version here.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
